### PR TITLE
Handshake: Fix incorrectly described format

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ The server can respond in three different ways:
 
   The handshake was successful.
 
-  The body of the response should contain the session id (`sid`) given to the
-  client, followed by the heartbeat timeout, the connection closing timeout,
-  and the list of supported transports separated by `:`
+  The response will provide the following elements seperated by `:` in order: the
+  session id (sid), the heartbeat timeout, the connection closing timeout, and
+  finally the list of supported transport formats.
+
+  The list of transport formats will be seperated by `,`.
 
   The absence of a heartbeat timeout ('') is interpreted as the server and
   client not expecting heartbeats.


### PR DESCRIPTION
The handshake response format is separated by ':' for the heartbeat
timeout, close timeout, and the transport formats as a whole. However
it's worth noting that the transports format list itself is
delineated by ','.
